### PR TITLE
Frontend auth integration (login/signup/logout + CSRF)

### DIFF
--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { fetchProgress, logout } from "../../lib/api";
 
 export default function DashboardPage() {
   const [progress, setProgress] = useState([]);
   const [status, setStatus] = useState("");
+  const [needsLogin, setNeedsLogin] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     let mounted = true;
@@ -17,7 +20,12 @@ export default function DashboardPage() {
       })
       .catch((error) => {
         if (mounted) {
-          setStatus(error.message);
+          if (error.status === 401) {
+            setNeedsLogin(true);
+            setStatus("Нужно войти, чтобы увидеть прогресс.");
+          } else {
+            setStatus(error.message);
+          }
         }
       });
 
@@ -31,6 +39,7 @@ export default function DashboardPage() {
     try {
       await logout();
       setStatus("Вы вышли из системы");
+      router.push("/login");
     } catch (error) {
       setStatus(error.message);
     }
@@ -43,6 +52,11 @@ export default function DashboardPage() {
         Выйти
       </button>
       {status && <p><small>{status}</small></p>}
+      {needsLogin && (
+        <p>
+          <a href="/login">Перейти к входу</a>
+        </p>
+      )}
       <h2>Прогресс</h2>
       {progress.length === 0 && <p><small>Пока нет данных.</small></p>}
       <ul>

--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { login } from "../../lib/api";
 
 export default function LoginPage() {
@@ -8,6 +9,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -16,6 +18,7 @@ export default function LoginPage() {
     try {
       await login({ email, password });
       setStatus("Успешный вход");
+      router.push("/dashboard");
     } catch (error) {
       setStatus(error.message);
     } finally {

--- a/frontend/app/signup/page.jsx
+++ b/frontend/app/signup/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { signup } from "../../lib/api";
 
 export default function SignupPage() {
@@ -8,6 +9,7 @@ export default function SignupPage() {
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -16,6 +18,7 @@ export default function SignupPage() {
     try {
       await signup({ email, password });
       setStatus("Регистрация успешна");
+      router.push("/dashboard");
     } catch (error) {
       setStatus(error.message);
     } finally {

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,19 +1,40 @@
 const getApiBase = () => process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000";
+const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+function readCookie(name) {
+  if (typeof document === "undefined") {
+    return "";
+  }
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : "";
+}
 
 async function request(path, options = {}) {
+  const method = (options.method || "GET").toUpperCase();
+  const headers = {
+    "Content-Type": "application/json",
+    ...(options.headers || {}),
+  };
+
+  if (!SAFE_METHODS.includes(method)) {
+    const csrfToken = readCookie("csrf_token");
+    if (csrfToken) {
+      headers["x-csrf-token"] = csrfToken;
+    }
+  }
+
   const response = await fetch(`${getApiBase()}${path}`, {
     credentials: "include",
-    headers: {
-      "Content-Type": "application/json",
-      ...(options.headers || {}),
-    },
+    headers,
     ...options,
   });
 
   const data = await response.json().catch(() => ({}));
   if (!response.ok) {
     const message = data.detail || "Request failed";
-    throw new Error(message);
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
   }
 
   return data;

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 process.env.NEXT_PUBLIC_API_BASE = "http://test";
 
-import { fetchProgress, login } from "../lib/api";
+import { fetchProgress, login, logout } from "../lib/api";
 
 const mockFetch = (payload, ok = true) =>
   vi.fn().mockResolvedValue({
@@ -34,6 +34,38 @@ describe("api client", () => {
     await expect(login({ email: "a@b.com", password: "bad" })).rejects.toThrow(
       "Invalid"
     );
+  });
+
+  it("error exposes status", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: vi.fn().mockResolvedValue({ detail: "Unauthorized" }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    try {
+      await fetchProgress();
+    } catch (error) {
+      expect(error.status).toBe(401);
+    }
+  });
+
+  it("adds csrf token for non-GET requests", async () => {
+    global.document = { cookie: "csrf_token=abc123" };
+    const fetchSpy = mockFetch({ detail: "ok" });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await logout();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://test/auth/logout",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "x-csrf-token": "abc123" }),
+      })
+    );
+
+    delete global.document;
   });
 
   it("fetchProgress returns array", async () => {


### PR DESCRIPTION
## Что сделано
- Интеграция login/signup/logout с API клиентом
- Редирект на /dashboard после успешной авторизации
- Logout возвращает на /login
- Dashboard показывает сообщение при 401 и ссылку на вход
- Добавлен CSRF заголовок для non-GET запросов
- Обновлены тесты API клиента

## Тесты
- npm test (frontend)

Closes #7
