### PR TITLE
fix: deploy fails on /login prerender (useSearchParams)

### DIFF
--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { login } from "../../lib/api";
 
 export default function LoginPage() {
@@ -10,9 +10,12 @@ export default function LoginPage() {
   const [status, setStatus] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const searchParams = useSearchParams();
+  const [verified, setVerified] = useState(false);
 
-  const verified = searchParams.get("verified");
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setVerified(params.get("verified") === "1");
+  }, []);
 
   const handleSubmit = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Что сломалось
В workflow deploy (run 24264572898) падал шаг **Deploy to server** на `next build` с ошибкой:
- `useSearchParams() should be wrapped in a suspense boundary at page "/login"`
- `Error occurred prerendering page "/login"`

## Что исправлено
- В `frontend/app/login/page.jsx` убран `useSearchParams`.
- Чтение query-параметра `verified` перенесено в `useEffect` через `window.location.search`.
- Это убирает требование Suspense boundary для prerender/static export страницы.

## Проверка
- Локально выполнено `npm install && npm run build` в `frontend/`.
- Сборка проходит, страница `/login` успешно prerenderится.

## Связь с инцидентом
Фикс закрывает причину падения deploy в run `24264572898`.
