### PR TITLE
feat: stage 5 questions DB and GET /questions filters

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 import secrets
 import subprocess
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.responses import RedirectResponse
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -322,17 +322,36 @@ async def generate_plan(
 
 
 @router.get("/questions")
-async def get_questions(topic: str | None = None, db: AsyncSession = Depends(get_db)):
+async def get_questions(
+    topic: str | None = Query(default=None, min_length=1, max_length=120),
+    difficulty: str | None = Query(default=None, pattern="^(junior|middle|senior)$"),
+    tags: list[str] | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
     stmt = select(Question)
-    if topic:
+
+    if topic is not None:
         stmt = stmt.where(Question.topic == topic)
+
+    if difficulty is not None:
+        stmt = stmt.where(Question.difficulty == difficulty)
+
+    if tags:
+        normalized_tags = [tag.strip() for tag in tags if tag.strip()]
+        if len(normalized_tags) != len(tags):
+            raise HTTPException(status_code=422, detail="Tags must be non-empty strings")
+        for tag in normalized_tags:
+            stmt = stmt.where(Question.tags.like(f"%{tag}%"))
+
     res = await db.execute(stmt)
     return [
         {
             "id": q.id,
+            "text": q.text,
             "topic": q.topic,
             "difficulty": q.difficulty,
-            "text": q.text,
+            "tags": [tag.strip() for tag in q.tags.split(",") if tag.strip()],
+            "created_at": q.created_at,
             "sample_answer": q.sample_answer,
         }
         for q in res.scalars().all()

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -8,7 +8,7 @@ import subprocess
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
 from fastapi.responses import RedirectResponse
-from sqlalchemy import select, func
+from sqlalchemy import select, func, String
 from sqlalchemy.ext.asyncio import AsyncSession
 from striprtf.striprtf import rtf_to_text
 from docx import Document
@@ -340,8 +340,10 @@ async def get_questions(
         normalized_tags = [tag.strip() for tag in tags if tag.strip()]
         if len(normalized_tags) != len(tags):
             raise HTTPException(status_code=422, detail="Tags must be non-empty strings")
+        tags_with_commas = func.concat(",", func.replace(Question.tags, " ", ""), ",").cast(String)
         for tag in normalized_tags:
-            stmt = stmt.where(Question.tags.like(f"%{tag}%"))
+            normalized_tag = tag.replace(" ", "")
+            stmt = stmt.where(tags_with_commas.like(f"%,{normalized_tag},%"))
 
     res = await db.execute(stmt)
     return [

--- a/backend/app/db/seed_questions.py
+++ b/backend/app/db/seed_questions.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 
@@ -44,7 +44,7 @@ async def seed_questions() -> int:
                     topic=item["topic"],
                     difficulty=item["difficulty"],
                     tags=item["tags"],
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     sample_answer=item["sample_answer"],
                 )
             )

--- a/backend/app/db/seed_questions.py
+++ b/backend/app/db/seed_questions.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+from sqlalchemy import select
+
+from app.db.session import AsyncSessionLocal
+from app.models.question import Question
+
+SEED_QUESTIONS = [
+    {
+        "text": "Что такое GIL в Python и как он влияет на многопоточность?",
+        "topic": "python",
+        "difficulty": "middle",
+        "tags": "python,concurrency,threads",
+        "sample_answer": "GIL ограничивает одновременное выполнение Python-байткода в одном процессе.",
+    },
+    {
+        "text": "Объясните разницу между LEFT JOIN и INNER JOIN.",
+        "topic": "database",
+        "difficulty": "junior",
+        "tags": "sql,joins,postgres",
+        "sample_answer": "INNER JOIN оставляет только пересечение, LEFT JOIN сохраняет все строки из левой таблицы.",
+    },
+    {
+        "text": "Как спроектировать rate limiter для API?",
+        "topic": "system-design",
+        "difficulty": "senior",
+        "tags": "architecture,api,scaling",
+        "sample_answer": "Через токен-бакет/слидинг-виндоу с Redis и атомарными операциями.",
+    },
+]
+
+
+async def seed_questions() -> int:
+    inserted = 0
+    async with AsyncSessionLocal() as db:
+        for item in SEED_QUESTIONS:
+            exists = await db.execute(select(Question).where(Question.text == item["text"]))
+            if exists.scalar_one_or_none() is not None:
+                continue
+
+            db.add(
+                Question(
+                    text=item["text"],
+                    topic=item["topic"],
+                    difficulty=item["difficulty"],
+                    tags=item["tags"],
+                    created_at=datetime.utcnow(),
+                    sample_answer=item["sample_answer"],
+                )
+            )
+            inserted += 1
+
+        await db.commit()
+    return inserted
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    count = asyncio.run(seed_questions())
+    print(f"Inserted {count} questions")

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
@@ -14,5 +14,9 @@ class Question(Base):
     topic: Mapped[str] = mapped_column(String(120), index=True, nullable=False)
     difficulty: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
     tags: Mapped[str] = mapped_column(String(512), index=True, nullable=False, default="")
-    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
     sample_answer: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/models/question.py
+++ b/backend/app/models/question.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Integer, String, Text
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.session import Base
@@ -8,7 +10,9 @@ class Question(Base):
     __tablename__ = "questions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
     topic: Mapped[str] = mapped_column(String(120), index=True, nullable=False)
     difficulty: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
-    text: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[str] = mapped_column(String(512), index=True, nullable=False, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     sample_answer: Mapped[str | None] = mapped_column(Text)

--- a/backend/tests/test_questions.py
+++ b/backend/tests/test_questions.py
@@ -1,0 +1,218 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models.question import Question
+
+
+@pytest.mark.asyncio
+async def test_get_questions_without_filters_returns_all(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add_all(
+            [
+                Question(
+                    text="Explain Python GIL",
+                    topic="python",
+                    difficulty="middle",
+                    tags="python,concurrency",
+                    created_at=datetime.now(timezone.utc),
+                ),
+                Question(
+                    text="What is index in PostgreSQL?",
+                    topic="database",
+                    difficulty="junior",
+                    tags="postgres,index",
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = await client.get("/questions")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 2
+    assert {item["topic"] for item in payload} == {"python", "database"}
+
+
+@pytest.mark.asyncio
+async def test_get_questions_topic_filter(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add_all(
+            [
+                Question(
+                    text="Q1",
+                    topic="python",
+                    difficulty="middle",
+                    tags="python",
+                    created_at=datetime.now(timezone.utc),
+                ),
+                Question(
+                    text="Q2",
+                    topic="system-design",
+                    difficulty="senior",
+                    tags="architecture",
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = await client.get("/questions", params={"topic": "python"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["topic"] == "python"
+
+
+@pytest.mark.asyncio
+async def test_get_questions_difficulty_filter(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add_all(
+            [
+                Question(
+                    text="Q1",
+                    topic="python",
+                    difficulty="junior",
+                    tags="python",
+                    created_at=datetime.now(timezone.utc),
+                ),
+                Question(
+                    text="Q2",
+                    topic="python",
+                    difficulty="senior",
+                    tags="python",
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = await client.get("/questions", params={"difficulty": "senior"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["difficulty"] == "senior"
+
+
+@pytest.mark.asyncio
+async def test_get_questions_tags_filter(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add_all(
+            [
+                Question(
+                    text="Q1",
+                    topic="python",
+                    difficulty="middle",
+                    tags="python,asyncio",
+                    created_at=datetime.now(timezone.utc),
+                ),
+                Question(
+                    text="Q2",
+                    topic="python",
+                    difficulty="middle",
+                    tags="python,oop",
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = await client.get("/questions", params=[("tags", "asyncio")])
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["text"] == "Q1"
+
+
+@pytest.mark.asyncio
+async def test_get_questions_combined_filters(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add_all(
+            [
+                Question(
+                    text="Q1",
+                    topic="python",
+                    difficulty="middle",
+                    tags="python,asyncio",
+                    created_at=datetime.now(timezone.utc),
+                ),
+                Question(
+                    text="Q2",
+                    topic="python",
+                    difficulty="senior",
+                    tags="python,asyncio",
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = await client.get(
+        "/questions",
+        params=[("topic", "python"), ("difficulty", "middle"), ("tags", "asyncio")],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["text"] == "Q1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"topic": ""},
+        {"difficulty": ""},
+        {"difficulty": "invalid-level"},
+        [("tags", "")],
+    ],
+)
+async def test_get_questions_invalid_filters_return_422(client, params):
+    response = await client.get("/questions", params=params)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_questions_empty_db_returns_empty_list(client):
+    response = await client.get("/questions")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_questions_filters_without_matches_returns_empty_list(client):
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as db:
+        db.add(
+            Question(
+                text="Q1",
+                topic="python",
+                difficulty="middle",
+                tags="python,asyncio",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await db.commit()
+
+    response = await client.get("/questions", params={"topic": "go"})
+
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
Closes #17\n\nImplemented:\n- extended Question model fields (text, topic, difficulty, tags, created_at)\n- added GET /questions filters: topic, difficulty, tags\n- added input validation and 422 on invalid params\n- added seed script backend/app/db/seed_questions.py\n- added comprehensive tests: happy/negative/edge for /questions\n\nTests:\n- pytest backend/tests/test_questions.py -v