### PR TITLE
feat: dashboard UX overhaul for readable step-by-step flow

### DIFF
--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { fetchProgress, generatePlan, ingestVacancy, logout } from "../../lib/api";
 
@@ -17,9 +17,24 @@ const defaultBrief = {
   language: "RU",
 };
 
+const priorityOptions = [
+  "Алгоритмы",
+  "System Design",
+  "Python Internals",
+  "SQL",
+  "Backend Architecture",
+  "Поведенческая часть (behavioral)",
+];
+
+const statusTypeMap = {
+  success: "alert-success",
+  error: "alert-error",
+  info: "alert-info",
+};
+
 export default function DashboardPage() {
   const [progress, setProgress] = useState([]);
-  const [status, setStatus] = useState("");
+  const [status, setStatus] = useState({ type: "", message: "" });
   const [needsLogin, setNeedsLogin] = useState(false);
   const [vacancyMode, setVacancyMode] = useState("raw_text");
   const [vacancyInput, setVacancyInput] = useState("");
@@ -27,7 +42,14 @@ export default function DashboardPage() {
   const [resumeText, setResumeText] = useState("");
   const [brief, setBrief] = useState(defaultBrief);
   const [planResult, setPlanResult] = useState(null);
+  const [isIngestLoading, setIsIngestLoading] = useState(false);
+  const [isGenerateLoading, setIsGenerateLoading] = useState(false);
+  const [isLogoutLoading, setIsLogoutLoading] = useState(false);
   const router = useRouter();
+
+  const canGeneratePlan = useMemo(() => {
+    return Boolean(vacancyText.trim() && brief.target_role.trim());
+  }, [vacancyText, brief.target_role]);
 
   useEffect(() => {
     let mounted = true;
@@ -38,14 +60,17 @@ export default function DashboardPage() {
         }
       })
       .catch((error) => {
-        if (mounted) {
-          if (error.status === 401) {
-            setNeedsLogin(true);
-            setStatus("Нужно войти, чтобы увидеть прогресс.");
-          } else {
-            setStatus(error.message);
-          }
+        if (!mounted) {
+          return;
         }
+
+        if (error.status === 401) {
+          setNeedsLogin(true);
+          setStatus({ type: "info", message: "Нужно войти, чтобы увидеть прогресс." });
+          return;
+        }
+
+        setStatus({ type: "error", message: error.message || "Не удалось загрузить прогресс." });
       });
 
     return () => {
@@ -54,13 +79,16 @@ export default function DashboardPage() {
   }, []);
 
   const handleLogout = async () => {
-    setStatus("");
+    setStatus({ type: "", message: "" });
+    setIsLogoutLoading(true);
     try {
       await logout();
-      setStatus("Вы вышли из системы");
+      setStatus({ type: "success", message: "Вы вышли из системы." });
       router.push("/login");
     } catch (error) {
-      setStatus(error.message);
+      setStatus({ type: "error", message: error.message || "Не удалось выйти из системы." });
+    } finally {
+      setIsLogoutLoading(false);
     }
   };
 
@@ -68,27 +96,44 @@ export default function DashboardPage() {
     setBrief((prev) => ({
       ...prev,
       priorities: checked
-        ? [...prev.priorities, value]
+        ? [...new Set([...prev.priorities, value])]
         : prev.priorities.filter((item) => item !== value),
     }));
   };
 
   const handleIngestVacancy = async () => {
-    setStatus("");
+    setStatus({ type: "", message: "" });
+    if (!vacancyInput.trim()) {
+      setStatus({ type: "error", message: "Заполните текст вакансии или ссылку." });
+      return;
+    }
+
+    setIsIngestLoading(true);
     try {
       const payload = vacancyMode === "url" ? { url: vacancyInput } : { raw_text: vacancyInput };
       const response = await ingestVacancy(payload);
-      setVacancyText(response.vacancy_text);
-      setStatus("Текст вакансии успешно обработан");
+      setVacancyText(response.vacancy_text || "");
+      setStatus({ type: "success", message: "Текст вакансии успешно обработан." });
     } catch (error) {
-      setStatus(error.message);
+      setStatus({ type: "error", message: error.message || "Ошибка обработки вакансии." });
+    } finally {
+      setIsIngestLoading(false);
     }
   };
 
   const handleGeneratePlan = async () => {
-    setStatus("");
+    setStatus({ type: "", message: "" });
     setPlanResult(null);
 
+    if (!canGeneratePlan) {
+      setStatus({
+        type: "info",
+        message: "Для генерации заполните целевую роль и обработайте вакансию.",
+      });
+      return;
+    }
+
+    setIsGenerateLoading(true);
     try {
       const response = await generatePlan({
         resume_text: resumeText || undefined,
@@ -110,149 +155,260 @@ export default function DashboardPage() {
       });
 
       setPlanResult(response);
-      setStatus("План подготовки сгенерирован");
+      setStatus({ type: "success", message: "План подготовки сгенерирован." });
     } catch (error) {
-      setStatus(error.message);
+      setStatus({ type: "error", message: error.message || "Ошибка генерации плана." });
+    } finally {
+      setIsGenerateLoading(false);
     }
   };
 
   return (
-    <section className="card">
-      <h1>Dashboard</h1>
-      <button type="button" onClick={handleLogout}>
-        Выйти
-      </button>
-      {status && <p><small>{status}</small></p>}
-      {needsLogin && (
-        <p>
-          <a href="/login">Перейти к входу</a>
-        </p>
-      )}
-
-      <h2>План подготовки</h2>
-      <p><small>Бриф включает 8 полей (без дневного трекинга).</small></p>
-
-      <label>
-        Текст резюме (опционально, если уже загружено резюме)
-        <textarea value={resumeText} onChange={(e) => setResumeText(e.target.value)} rows={4} />
-      </label>
-
-      <label>
-        Источник вакансии
-        <select value={vacancyMode} onChange={(e) => setVacancyMode(e.target.value)}>
-          <option value="raw_text">Полный текст вакансии</option>
-          <option value="url">Ссылка на вакансию</option>
-        </select>
-      </label>
-      <textarea
-        rows={4}
-        value={vacancyInput}
-        onChange={(e) => setVacancyInput(e.target.value)}
-        placeholder={vacancyMode === "url" ? "https://..." : "Вставьте текст вакансии"}
-      />
-      <button type="button" onClick={handleIngestVacancy}>Обработать вакансию</button>
-
-      <label>
-        Целевая роль/позиция
-        <input value={brief.target_role} onChange={(e) => setBrief({ ...brief, target_role: e.target.value })} />
-      </label>
-
-      <label>
-        Уровень
-        <select value={brief.level} onChange={(e) => setBrief({ ...brief, level: e.target.value })}>
-          <option>Junior</option><option>Junior+</option><option>Middle</option><option>Middle+</option><option>Senior</option>
-        </select>
-      </label>
-
-      <label>
-        Горизонт подготовки
-        <select
-          value={brief.horizon_weeks}
-          onChange={(e) => setBrief({ ...brief, horizon_weeks: Number(e.target.value) })}
-        >
-          <option value={2}>2 недели</option>
-          <option value={4}>4 недели</option>
-          <option value={6}>6 недель</option>
-        </select>
-      </label>
-
-      <label>
-        Часы в будни
-        <input
-          type="number"
-          value={brief.weekday_hours}
-          onChange={(e) => setBrief({ ...brief, weekday_hours: Number(e.target.value) })}
-        />
-      </label>
-
-      <label>
-        Часы в выходные
-        <input
-          type="number"
-          value={brief.weekend_hours}
-          onChange={(e) => setBrief({ ...brief, weekend_hours: Number(e.target.value) })}
-        />
-      </label>
-
-      <label>
-        Формат плана
-        <select value={brief.plan_format} onChange={(e) => setBrief({ ...brief, plan_format: e.target.value })}>
-          <option value="themes">темы</option>
-          <option value="themes+practice">темы+практика</option>
-          <option value="themes+practice+mock_interview">темы+практика+mock interview</option>
-        </select>
-      </label>
-
-      <fieldset>
-        <legend>Приоритеты</legend>
-        {["Алгоритмы", "System Design", "Python Internals", "SQL", "Backend Architecture", "Поведенческая часть (behavioral)"]
-          .map((item) => (
-            <label key={item} style={{ display: "block" }}>
-              <input
-                type="checkbox"
-                checked={brief.priorities.includes(item)}
-                onChange={(e) => handlePriorityChange(item, e.target.checked)}
-              />
-              {item}
-            </label>
-          ))}
-        <label>
-          Другое
-          <input value={brief.other_priority} onChange={(e) => setBrief({ ...brief, other_priority: e.target.value })} />
-        </label>
-      </fieldset>
-
-      <label>
-        Ограничения/предпочтения
-        <textarea value={brief.constraints} onChange={(e) => setBrief({ ...brief, constraints: e.target.value })} rows={3} />
-      </label>
-
-      <label>
-        Язык подготовки
-        <select value={brief.language} onChange={(e) => setBrief({ ...brief, language: e.target.value })}>
-          <option value="RU">RU</option>
-          <option value="EN">EN</option>
-        </select>
-      </label>
-
-      <button type="button" onClick={handleGeneratePlan}>Сгенерировать план</button>
-
-      {planResult && (
+    <section className="dashboard">
+      <header className="card section header-section">
         <div>
-          <h3>Результат (plan_id: {planResult.plan_id})</h3>
-          <pre>{JSON.stringify(planResult.plan, null, 2)}</pre>
+          <h1>Dashboard подготовки</h1>
+          <p className="muted">Соберите данные, сгенерируйте план и отслеживайте прогресс по шагам.</p>
+        </div>
+        <button type="button" onClick={handleLogout} disabled={isLogoutLoading}>
+          {isLogoutLoading ? "Выходим..." : "Выйти"}
+        </button>
+      </header>
+
+      {status.message && (
+        <div className={`alert ${statusTypeMap[status.type] || "alert-info"}`} role="status" aria-live="polite">
+          {status.message}
         </div>
       )}
 
-      <h2>Прогресс</h2>
-      {progress.length === 0 && <p><small>Пока нет данных.</small></p>}
-      <ul>
-        {progress.map((item) => (
-          <li key={`${item.topic}-${item.updated_at}`}>
-            {item.topic}: {item.status}
-          </li>
-        ))}
-      </ul>
+      {needsLogin && (
+        <div className="card section">
+          <a href="/login">Перейти к входу</a>
+        </div>
+      )}
+
+      <div className="card section">
+        <h2>Шаг 1. Резюме и вакансия</h2>
+        <div className="field">
+          <label htmlFor="resume-text">Текст резюме (опционально)</label>
+          <textarea
+            id="resume-text"
+            value={resumeText}
+            onChange={(e) => setResumeText(e.target.value)}
+            rows={5}
+            placeholder="Вставьте резюме, если хотите уточнить персональные рекомендации"
+          />
+        </div>
+
+        <div className="field-grid">
+          <div className="field">
+            <label htmlFor="vacancy-source">Источник вакансии</label>
+            <select id="vacancy-source" value={vacancyMode} onChange={(e) => setVacancyMode(e.target.value)}>
+              <option value="raw_text">Полный текст вакансии</option>
+              <option value="url">Ссылка на вакансию</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="field">
+          <label htmlFor="vacancy-input">Входные данные вакансии</label>
+          <textarea
+            id="vacancy-input"
+            rows={5}
+            value={vacancyInput}
+            onChange={(e) => setVacancyInput(e.target.value)}
+            placeholder={vacancyMode === "url" ? "https://..." : "Вставьте текст вакансии"}
+          />
+        </div>
+
+        <button type="button" onClick={handleIngestVacancy} disabled={isIngestLoading}>
+          {isIngestLoading ? "Обрабатываем..." : "Обработать вакансию"}
+        </button>
+
+        <div className="field">
+          <label htmlFor="vacancy-processed">Обработанный текст вакансии</label>
+          <textarea id="vacancy-processed" rows={5} value={vacancyText} readOnly placeholder="Появится после обработки" />
+        </div>
+      </div>
+
+      <div className="card section">
+        <h2>Шаг 2. Бриф подготовки</h2>
+        <div className="field-grid">
+          <div className="field">
+            <label htmlFor="target-role">Целевая роль</label>
+            <input
+              id="target-role"
+              value={brief.target_role}
+              onChange={(e) => setBrief({ ...brief, target_role: e.target.value })}
+              placeholder="Backend Engineer"
+            />
+          </div>
+
+          <div className="field">
+            <label htmlFor="level">Уровень</label>
+            <select id="level" value={brief.level} onChange={(e) => setBrief({ ...brief, level: e.target.value })}>
+              <option>Junior</option>
+              <option>Junior+</option>
+              <option>Middle</option>
+              <option>Middle+</option>
+              <option>Senior</option>
+            </select>
+          </div>
+
+          <div className="field">
+            <label htmlFor="horizon">Горизонт подготовки</label>
+            <select
+              id="horizon"
+              value={brief.horizon_weeks}
+              onChange={(e) => setBrief({ ...brief, horizon_weeks: Number(e.target.value) })}
+            >
+              <option value={2}>2 недели</option>
+              <option value={4}>4 недели</option>
+              <option value={6}>6 недель</option>
+            </select>
+          </div>
+
+          <div className="field">
+            <label htmlFor="plan-format">Формат плана</label>
+            <select
+              id="plan-format"
+              value={brief.plan_format}
+              onChange={(e) => setBrief({ ...brief, plan_format: e.target.value })}
+            >
+              <option value="themes">темы</option>
+              <option value="themes+practice">темы+практика</option>
+              <option value="themes+practice+mock_interview">темы+практика+mock interview</option>
+            </select>
+          </div>
+
+          <div className="field">
+            <label htmlFor="weekday-hours">Часы в будни</label>
+            <input
+              id="weekday-hours"
+              type="number"
+              min={0}
+              value={brief.weekday_hours}
+              onChange={(e) => setBrief({ ...brief, weekday_hours: Number(e.target.value) })}
+            />
+          </div>
+
+          <div className="field">
+            <label htmlFor="weekend-hours">Часы в выходные</label>
+            <input
+              id="weekend-hours"
+              type="number"
+              min={0}
+              value={brief.weekend_hours}
+              onChange={(e) => setBrief({ ...brief, weekend_hours: Number(e.target.value) })}
+            />
+          </div>
+
+          <div className="field">
+            <label htmlFor="language">Язык подготовки</label>
+            <select id="language" value={brief.language} onChange={(e) => setBrief({ ...brief, language: e.target.value })}>
+              <option value="RU">RU</option>
+              <option value="EN">EN</option>
+            </select>
+          </div>
+        </div>
+
+        <fieldset className="priority-fieldset">
+          <legend>Приоритеты</legend>
+          <div className="priority-grid">
+            {priorityOptions.map((item) => (
+              <label key={item} className="priority-item">
+                <input
+                  type="checkbox"
+                  checked={brief.priorities.includes(item)}
+                  onChange={(e) => handlePriorityChange(item, e.target.checked)}
+                />
+                <span>{item}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <div className="field-grid">
+          <div className="field">
+            <label htmlFor="other-priority">Другое (опционально)</label>
+            <input
+              id="other-priority"
+              value={brief.other_priority}
+              onChange={(e) => setBrief({ ...brief, other_priority: e.target.value })}
+            />
+          </div>
+        </div>
+
+        <div className="field">
+          <label htmlFor="constraints">Ограничения и предпочтения</label>
+          <textarea
+            id="constraints"
+            value={brief.constraints}
+            onChange={(e) => setBrief({ ...brief, constraints: e.target.value })}
+            rows={4}
+          />
+        </div>
+      </div>
+
+      <div className="card section">
+        <h2>Шаг 3. Генерация плана</h2>
+        <p className="muted">Минимум для запуска: обработанная вакансия и целевая роль.</p>
+        <button type="button" onClick={handleGeneratePlan} disabled={!canGeneratePlan || isGenerateLoading}>
+          {isGenerateLoading ? "Генерируем..." : "Сгенерировать план"}
+        </button>
+      </div>
+
+      <div className="card section">
+        <h2>Результат плана</h2>
+        {!planResult && <p className="muted">После генерации здесь появится структура плана.</p>}
+        {planResult && (
+          <div className="plan-result">
+            <p>
+              <strong>Plan ID:</strong> {planResult.plan_id || "-"}
+            </p>
+
+            {Array.isArray(planResult?.plan?.weeks) && planResult.plan.weeks.length > 0 ? (
+              <div className="plan-list">
+                {planResult.plan.weeks.map((week, index) => (
+                  <div key={week.week || index} className="plan-item">
+                    <h3>Неделя {week.week || index + 1}</h3>
+                    {Array.isArray(week.topics) && week.topics.length > 0 ? (
+                      <ul>
+                        {week.topics.map((topic) => (
+                          <li key={topic}>{topic}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="muted">Темы не указаны.</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <pre>{JSON.stringify(planResult.plan, null, 2)}</pre>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="card section">
+        <h2>Прогресс</h2>
+        {progress.length === 0 ? (
+          <div className="empty-state">
+            <p>Пока нет записей прогресса.</p>
+            <p className="muted">Сгенерируйте план и начните отмечать выполнение шагов.</p>
+          </div>
+        ) : (
+          <ul className="progress-list">
+            {progress.map((item) => (
+              <li key={`${item.topic}-${item.updated_at}`} className="progress-item">
+                <span>{item.topic}</span>
+                <span className="status-badge">{item.status}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </section>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3,6 +3,10 @@
   font-family: Inter, system-ui, -apple-system, sans-serif;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   background: #f6f7fb;
@@ -10,16 +14,46 @@ body {
 }
 
 main {
-  max-width: 920px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 48px 20px;
+  padding: 48px 16px;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
 }
 
 .card {
   background: #fff;
   border-radius: 16px;
   padding: 24px;
-  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.08);
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.06);
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section h2 {
+  margin-bottom: 16px;
+}
+
+.header-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.muted,
+small {
+  color: #59627a;
 }
 
 .field {
@@ -29,11 +63,57 @@ main {
   margin-bottom: 16px;
 }
 
-input, textarea {
-  padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid #d6d9e0;
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+label,
+legend {
   font-size: 14px;
+  font-weight: 600;
+  color: #2a324b;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cfd6e3;
+  font-size: 14px;
+  color: #1d1f2a;
+  background: #fff;
+}
+
+input:hover,
+textarea:hover,
+select:hover {
+  border-color: #9eb0d2;
+}
+
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 3px solid #c9d8fb;
+  outline-offset: 1px;
+  border-color: #2d6cdf;
+}
+
+input:disabled,
+textarea:disabled,
+select:disabled {
+  background: #f2f4f8;
+  color: #77809a;
+  cursor: not-allowed;
+}
+
+textarea[readonly] {
+  background: #f7f9fc;
 }
 
 button {
@@ -41,28 +121,149 @@ button {
   color: #fff;
   border: none;
   padding: 10px 16px;
-  border-radius: 8px;
+  border-radius: 10px;
   font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
 }
 
+button:hover {
+  background: #255ac2;
+}
+
 button:disabled {
-  background: #b5c6ec;
+  background: #a9bbde;
   cursor: not-allowed;
 }
 
-nav {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 24px;
+.alert {
+  border-radius: 12px;
+  padding: 12px 14px;
+  border: 1px solid;
+  font-size: 14px;
 }
 
-nav a {
-  color: #2d6cdf;
-  text-decoration: none;
+.alert-success {
+  background: #edfdf2;
+  border-color: #86efac;
+  color: #166534;
+}
+
+.alert-error {
+  background: #fef2f2;
+  border-color: #fca5a5;
+  color: #991b1b;
+}
+
+.alert-info {
+  background: #eff6ff;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.priority-fieldset {
+  border: 1px solid #dbe2ef;
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 16px;
+}
+
+.priority-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 12px;
+}
+
+.priority-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.priority-item input {
+  width: 16px;
+  height: 16px;
+}
+
+.plan-result pre {
+  background: #f3f6fc;
+  border: 1px solid #d7e0f1;
+  border-radius: 10px;
+  padding: 12px;
+  overflow-x: auto;
+}
+
+.plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.plan-item {
+  background: #f8faff;
+  border: 1px solid #d7e0f1;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.plan-item ul {
+  margin: 8px 0 0;
+  padding-left: 20px;
+}
+
+.progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f8faff;
+  border: 1px solid #d7e0f1;
+  border-radius: 10px;
+  padding: 10px 12px;
+  gap: 8px;
+}
+
+.status-badge {
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  padding: 2px 10px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-small {
-  color: #6b7280;
+.empty-state {
+  border: 1px dashed #c8d4ea;
+  border-radius: 12px;
+  padding: 14px;
+  background: #fafcff;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 28px 12px;
+  }
+
+  .card {
+    padding: 16px;
+  }
+
+  .header-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .field-grid,
+  .priority-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -14,9 +14,28 @@ body {
 }
 
 main {
-  max-width: 960px;
+  width: min(100%, 1060px);
   margin: 0 auto;
-  padding: 48px 16px;
+  padding: clamp(20px, 4vw, 48px) clamp(12px, 2.5vw, 20px);
+}
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.top-nav a {
+  text-decoration: none;
+  color: #255ac2;
+  font-weight: 700;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.top-nav a:hover {
+  background: #e8f0ff;
 }
 
 h1,
@@ -38,6 +57,11 @@ p {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.dashboard > .card {
+  width: 100%;
+  overflow: hidden;
 }
 
 .section h2 {
@@ -69,6 +93,11 @@ small {
   gap: 12px;
 }
 
+.field-grid > *,
+.priority-grid > * {
+  min-width: 0;
+}
+
 label,
 legend {
   font-size: 14px;
@@ -80,6 +109,7 @@ input,
 textarea,
 select {
   width: 100%;
+  max-width: 100%;
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid #cfd6e3;
@@ -179,6 +209,11 @@ button:disabled {
   align-items: center;
   gap: 8px;
   font-weight: 500;
+  min-width: 0;
+}
+
+.priority-item span {
+  overflow-wrap: anywhere;
 }
 
 .priority-item input {
@@ -255,6 +290,7 @@ button:disabled {
 
   .card {
     padding: 16px;
+    border-radius: 12px;
   }
 
   .header-section {
@@ -262,8 +298,31 @@ button:disabled {
     align-items: stretch;
   }
 
+  .top-nav {
+    gap: 6px;
+  }
+
+  .top-nav a {
+    padding: 4px 6px;
+  }
+
   .field-grid,
   .priority-grid {
     grid-template-columns: 1fr;
+  }
+
+  .progress-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 420px) {
+  .card {
+    padding: 14px;
+  }
+
+  button {
+    width: 100%;
   }
 }

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -10,7 +10,7 @@ export default function RootLayout({ children }) {
     <html lang="ru">
       <body>
         <main>
-          <nav>
+          <nav className="top-nav" aria-label="Основная навигация">
             <a href="/login">Login</a>
             <a href="/signup">Signup</a>
             <a href="/dashboard">Dashboard</a>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "playwright": "^1.59.1",
         "vitest": "1.6.0"
       }
     },
@@ -1652,6 +1653,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "playwright": "^1.59.1",
     "vitest": "1.6.0"
   }
 }


### PR DESCRIPTION
Closes #20

## Что сделано
- переработана структура /dashboard в карточный пошаговый UX (Шаг 1/2/3)
- добавлены loading-состояния для async кнопок (вакансия/генерация/logout)
- добавлены типизированные alert-сообщения (success/error/info)
- введены минимальные условия доступности кнопки генерации плана
- улучшен вывод результата плана (plan_id, структурный вывод по неделям, fallback в pre)
- переработан блок прогресса (список карточками + empty-state)
- обновлены стили и адаптивность (360/768/1280), focus/hover/disabled состояния
- включены изменения зависимостей с добавлением playwright в devDependencies

## Проверки
- npm test -- --watch=false ✅
- npm run build ✅
