### PR TITLE
Исправить ложное падение smoke-check после автодеплоя

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,21 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
             set -e
+            for i in $(seq 1 20); do
+              if curl -fsS http://127.0.0.1:8000/health >/tmp/interview_backend_health.json; then
+                break
+              fi
+              echo "waiting for backend health (${i}/20)"
+              sleep 2
+            done
+
+            for i in $(seq 1 20); do
+              if curl -fsS http://127.0.0.1:3000 >/tmp/interview_frontend_health.html; then
+                break
+              fi
+              echo "waiting for frontend health (${i}/20)"
+              sleep 2
+            done
+
             curl -fsS http://127.0.0.1:8000/health >/tmp/interview_backend_health.json
             curl -fsS http://127.0.0.1:3000 >/tmp/interview_frontend_health.html

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -3,6 +3,26 @@ set -e
 
 PROJECT=/projects/interview-botelo
 
+wait_for_url() {
+  local url=$1
+  local label=$2
+  local attempts=${3:-30}
+  local delay=${4:-2}
+
+  for ((i=1; i<=attempts; i++)); do
+    if curl -fsS "$url" >/dev/null; then
+      echo "==> ${label} is healthy"
+      return 0
+    fi
+
+    echo "==> waiting for ${label} (${i}/${attempts})"
+    sleep "$delay"
+  done
+
+  echo "==> ${label} did not become healthy in time"
+  return 1
+}
+
 echo '==> Pull latest code'
 cd $PROJECT
 git pull origin main
@@ -18,6 +38,10 @@ npm run build
 echo '==> Restart services'
 systemctl restart interview-coach
 systemctl restart interview-frontend
+
+echo '==> Wait for services to become healthy'
+wait_for_url http://127.0.0.1:8000/health "backend"
+wait_for_url http://127.0.0.1:3000 "frontend"
 
 echo '==> Done'
 systemctl is-active interview-coach interview-frontend


### PR DESCRIPTION
## Что сделано

Closes #28

Исправлено ложное падение smoke-check после автодеплоя в `main`.

- В `deploy/deploy.sh` добавлено ожидание готовности backend и frontend после рестарта сервисов.
- В шаге `Smoke health checks` workflow добавлены retry-циклы для backend и frontend перед финальной обязательной проверкой.
- Сценарий сохраняет автоматический деплой на `push` в `main`, но больше не должен падать из-за короткого окна старта backend.

## Что ожидаем в результате

- После merge в `main` deploy не падает на мгновенном health-check.
- Workflow ждёт готовности сервисов и только потом подтверждает успешную раскатку.

## Локальная проверка

- `bash -n deploy/deploy.sh`
