### PR TITLE
Исправить уязвимости auth/dashboard после PR #26

### DIFF
--- a/backend/app/services/csrf.py
+++ b/backend/app/services/csrf.py
@@ -6,7 +6,6 @@ SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
 EXEMPT_PATHS = {
     "/auth/login",
     "/auth/signup",
-    "/auth/logout",
     "/auth/resend-verification",
     "/auth/verify",
 }

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -117,3 +117,25 @@ async def test_resend_verification_behaviour(
             assert user.email_verification_token != old_token_hash
         else:
             assert user.email_verification_token is None
+
+
+@pytest.mark.asyncio
+async def test_logout_requires_csrf_token_after_login(client):
+    from app.db.session import SessionLocal
+
+    await client.post("/auth/signup", json={"email": "logout-csrf@test.com", "password": "pass1234"})
+
+    plain_token = "logout-csrf-token"
+    async with SessionLocal() as session:
+        res = await session.execute(select(User).where(User.email == "logout-csrf@test.com"))
+        user = res.scalar_one()
+        user.email_verification_token = hash_email_token(plain_token)
+        await session.commit()
+
+    await client.get(f"/auth/verify?token={plain_token}")
+    login = await client.post("/auth/login", json={"email": "logout-csrf@test.com", "password": "pass1234"})
+    assert login.status_code == 200
+
+    logout = await client.post("/auth/logout")
+    assert logout.status_code == 403
+    assert logout.json()["detail"] == "CSRF token missing/invalid"

--- a/frontend/app/dashboard/page.jsx
+++ b/frontend/app/dashboard/page.jsx
@@ -108,6 +108,12 @@ export default function DashboardPage() {
     window.localStorage.setItem(DRAFT_KEY, JSON.stringify(payload));
   }, [vacancyMode, vacancyInput, vacancyText, resumeText, brief]);
 
+  const redirectToLogin = (message) => {
+    setNeedsLogin(true);
+    setStatus({ type: "info", message });
+    router.replace("/?redirect=/dashboard");
+  };
+
   useEffect(() => {
     let mounted = true;
     fetchProgress()
@@ -122,9 +128,7 @@ export default function DashboardPage() {
         }
 
         if (error.status === 401) {
-          setNeedsLogin(true);
-          setStatus({ type: "info", message: "Нужно войти, чтобы увидеть прогресс." });
-          router.replace("/?redirect=/dashboard");
+          redirectToLogin("Нужно войти, чтобы увидеть прогресс.");
           return;
         }
 
@@ -141,6 +145,9 @@ export default function DashboardPage() {
     setIsLogoutLoading(true);
     try {
       await logout();
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(DRAFT_KEY);
+      }
       setStatus({ type: "success", message: "Вы вышли из системы." });
       router.push("/");
     } catch (error) {
@@ -173,6 +180,10 @@ export default function DashboardPage() {
       setVacancyText(response.vacancy_text || "");
       setStatus({ type: "success", message: "Текст вакансии успешно обработан." });
     } catch (error) {
+      if (error.status === 401) {
+        redirectToLogin("Сессия истекла. Войдите снова, чтобы продолжить.");
+        return;
+      }
       setStatus({ type: "error", message: error.message || "Ошибка обработки вакансии." });
     } finally {
       setIsIngestLoading(false);
@@ -216,6 +227,10 @@ export default function DashboardPage() {
       setCurrentStep(3);
       setStatus({ type: "success", message: "План подготовки сгенерирован." });
     } catch (error) {
+      if (error.status === 401) {
+        redirectToLogin("Сессия истекла. Войдите снова, чтобы продолжить.");
+        return;
+      }
       setStatus({ type: "error", message: error.message || "Ошибка генерации плана." });
     } finally {
       setIsGenerateLoading(false);

--- a/frontend/app/login/LoginForm.jsx
+++ b/frontend/app/login/LoginForm.jsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { login, signup } from "../../lib/api";
+import { sanitizeRedirectTarget } from "../../lib/auth-guards";
 
 export default function LoginForm({ initialMode = "login", redirectTo = "/dashboard", verified = false }) {
   const [mode, setMode] = useState(initialMode);
@@ -23,7 +24,7 @@ export default function LoginForm({ initialMode = "login", redirectTo = "/dashbo
       if (isLogin) {
         await login({ email, password });
         setStatus("Успешный вход");
-        router.push(redirectTo);
+        router.push(sanitizeRedirectTarget(redirectTo));
       } else {
         await signup({ email, password });
         setStatus("Проверьте почту и подтвердите email, затем войдите.");

--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+import { sanitizeRedirectTarget } from "../../lib/auth-guards";
+
 export default function LoginPage({ searchParams }) {
   const nextSearchParams = new URLSearchParams();
 
@@ -11,8 +13,9 @@ export default function LoginPage({ searchParams }) {
     nextSearchParams.set("verified", "1");
   }
 
-  if (typeof searchParams?.redirect === "string" && searchParams.redirect.startsWith("/")) {
-    nextSearchParams.set("redirect", searchParams.redirect);
+  const redirectTo = sanitizeRedirectTarget(searchParams?.redirect, "");
+  if (redirectTo) {
+    nextSearchParams.set("redirect", redirectTo);
   }
 
   const query = nextSearchParams.toString();

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -1,13 +1,12 @@
 import React from "react";
 
 import LoginForm from "./login/LoginForm";
+import { sanitizeRedirectTarget } from "../lib/auth-guards";
 
 export default function Home({ searchParams }) {
   const mode = searchParams?.mode === "signup" ? "signup" : "login";
   const verified = searchParams?.verified === "1";
-  const redirectTo = typeof searchParams?.redirect === "string" && searchParams.redirect.startsWith("/")
-    ? searchParams.redirect
-    : "/dashboard";
+  const redirectTo = sanitizeRedirectTarget(searchParams?.redirect);
 
   return <LoginForm initialMode={mode} redirectTo={redirectTo} verified={verified} />;
 }

--- a/frontend/lib/auth-guards.js
+++ b/frontend/lib/auth-guards.js
@@ -1,0 +1,58 @@
+const DEFAULT_REDIRECT = "/dashboard";
+const INTERNAL_ORIGIN = "http://local.test";
+
+export function sanitizeRedirectTarget(redirect, fallback = DEFAULT_REDIRECT) {
+  if (typeof redirect !== "string" || !redirect.startsWith("/") || redirect.startsWith("//")) {
+    return fallback;
+  }
+
+  try {
+    const parsed = new URL(redirect, INTERNAL_ORIGIN);
+    if (parsed.origin !== INTERNAL_ORIGIN) {
+      return fallback;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return fallback;
+  }
+}
+
+function decodeBase64Url(value) {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+
+  if (typeof atob === "function") {
+    return atob(padded);
+  }
+
+  return Buffer.from(padded, "base64").toString("utf-8");
+}
+
+export function isProbablyValidSessionCookie(token) {
+  if (typeof token !== "string") {
+    return false;
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(parts[1]));
+    const userId = Number(payload?.sub);
+    const expiresAt = Number(payload?.exp);
+
+    if (!Number.isInteger(userId) || userId <= 0) {
+      return false;
+    }
+
+    if (!Number.isFinite(expiresAt) || expiresAt <= Math.floor(Date.now() / 1000)) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/middleware.js
+++ b/frontend/middleware.js
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 
+import { isProbablyValidSessionCookie } from "./lib/auth-guards";
+
 export function middleware(request) {
   if (!request.nextUrl.pathname.startsWith("/dashboard")) {
     return NextResponse.next();
   }
 
   const session = request.cookies.get("session")?.value;
-  if (session) {
+  if (isProbablyValidSessionCookie(session)) {
     return NextResponse.next();
   }
 

--- a/frontend/tests/auth-guards.test.js
+++ b/frontend/tests/auth-guards.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isProbablyValidSessionCookie, sanitizeRedirectTarget } from "../lib/auth-guards";
+
+describe("auth guards", () => {
+  it("разрешает только безопасные внутренние redirect", () => {
+    expect(sanitizeRedirectTarget("/dashboard")).toBe("/dashboard");
+    expect(sanitizeRedirectTarget("/dashboard?tab=plan")).toBe("/dashboard?tab=plan");
+    expect(sanitizeRedirectTarget("//evil.com")).toBe("/dashboard");
+    expect(sanitizeRedirectTarget("https://evil.com")).toBe("/dashboard");
+    expect(sanitizeRedirectTarget(undefined)).toBe("/dashboard");
+  });
+
+  it("распознаёт валидную session cookie по структуре и exp", () => {
+    const payload = Buffer.from(JSON.stringify({
+      sub: "7",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })).toString("base64url");
+    const token = `header.${payload}.sig`;
+
+    expect(isProbablyValidSessionCookie(token)).toBe(true);
+    expect(isProbablyValidSessionCookie("garbage")).toBe(false);
+  });
+
+  it("отклоняет просроченную или неполную session cookie", () => {
+    const expiredPayload = Buffer.from(JSON.stringify({
+      sub: "7",
+      exp: Math.floor(Date.now() / 1000) - 10,
+    })).toString("base64url");
+    const missingSubjectPayload = Buffer.from(JSON.stringify({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })).toString("base64url");
+
+    expect(isProbablyValidSessionCookie(`header.${expiredPayload}.sig`)).toBe(false);
+    expect(isProbablyValidSessionCookie(`header.${missingSubjectPayload}.sig`)).toBe(false);
+  });
+});

--- a/frontend/tests/auth-routing.test.js
+++ b/frontend/tests/auth-routing.test.js
@@ -48,4 +48,31 @@ describe("auth routing", () => {
       expect.objectContaining({ initialMode: "signup", redirectTo: "/dashboard", verified: true })
     );
   });
+
+  it("home page отбрасывает внешний redirect", async () => {
+    const { default: Home } = await import("../app/page");
+
+    const element = Home({
+      searchParams: {
+        redirect: "//evil.com",
+      },
+    });
+
+    expect(element.props).toEqual(
+      expect.objectContaining({ redirectTo: "/dashboard" })
+    );
+  });
+
+  it("login page не прокидывает небезопасный redirect", async () => {
+    const { default: LoginPage } = await import("../app/login/page");
+    const { redirect } = await import("next/navigation");
+
+    LoginPage({
+      searchParams: {
+        redirect: "//evil.com",
+      },
+    });
+
+    expect(redirect).toHaveBeenCalledWith("/");
+  });
 });

--- a/frontend/tests/dashboard.test.jsx
+++ b/frontend/tests/dashboard.test.jsx
@@ -81,11 +81,13 @@ describe("dashboard wizard", () => {
 
   it("делает logout и редиректит на auth-first экран", async () => {
     api.logout.mockResolvedValue({ detail: "ok" });
+    window.localStorage.setItem("dashboardDraftV1", JSON.stringify({ vacancyInput: "secret" }));
     render(<DashboardPage />);
 
     await userEvent.click(screen.getByRole("button", { name: "Выйти" }));
 
     await waitFor(() => expect(api.logout).toHaveBeenCalledTimes(1));
+    expect(window.localStorage.getItem("dashboardDraftV1")).toBeNull();
     expect(pushMock).toHaveBeenCalledWith("/");
   });
 
@@ -108,5 +110,34 @@ describe("dashboard wizard", () => {
     await userEvent.click(screen.getByRole("button", { name: "Далее" }));
     expect(screen.getByRole("heading", { name: "Шаг 2. Бриф подготовки" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Далее" })).toBeDisabled();
+  });
+
+  it("возвращает на вход при 401 во время обработки вакансии", async () => {
+    api.ingestVacancy.mockRejectedValue(Object.assign(new Error("Unauthorized"), { status: 401 }));
+    render(<DashboardPage />);
+
+    await userEvent.type(screen.getByLabelText("Входные данные вакансии"), "text vacancy");
+    await userEvent.click(screen.getByRole("button", { name: "Обработать вакансию" }));
+
+    expect(await screen.findByText("Сессия истекла. Войдите снова, чтобы продолжить.")).toBeInTheDocument();
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/?redirect=/dashboard"));
+  });
+
+  it("возвращает на вход при 401 во время генерации плана", async () => {
+    api.ingestVacancy.mockResolvedValue({ vacancy_text: "Python backend role" });
+    api.generatePlan.mockRejectedValue(Object.assign(new Error("Unauthorized"), { status: 401 }));
+    render(<DashboardPage />);
+
+    await userEvent.type(screen.getByLabelText("Входные данные вакансии"), "text vacancy");
+    await userEvent.click(screen.getByRole("button", { name: "Обработать вакансию" }));
+    await waitFor(() => expect(api.ingestVacancy).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole("button", { name: "Далее" }));
+    await userEvent.type(screen.getByLabelText("Целевая роль *"), "Backend Engineer");
+    await userEvent.click(screen.getByRole("button", { name: "Далее" }));
+    await userEvent.click(screen.getByRole("button", { name: "Сгенерировать план" }));
+
+    expect(await screen.findByText("Сессия истекла. Войдите снова, чтобы продолжить.")).toBeInTheDocument();
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith("/?redirect=/dashboard"));
   });
 });

--- a/frontend/tests/middleware.test.js
+++ b/frontend/tests/middleware.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const nextMock = vi.fn(() => ({ type: "next" }));
+const redirectMock = vi.fn((url) => ({ type: "redirect", url: url.toString() }));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    next: nextMock,
+    redirect: redirectMock,
+  },
+}));
+
+describe("middleware auth gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("пропускает dashboard только с валидной session cookie", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const payload = Buffer.from(JSON.stringify({ sub: "1", exp: futureExp })).toString("base64url");
+    const { middleware } = await import("../middleware");
+
+    const response = middleware({
+      nextUrl: { pathname: "/dashboard" },
+      cookies: { get: () => ({ value: `h.${payload}.s` }) },
+      url: "http://localhost/dashboard",
+    });
+
+    expect(nextMock).toHaveBeenCalled();
+    expect(response).toEqual({ type: "next" });
+  });
+
+  it("редиректит при битой session cookie", async () => {
+    const { middleware } = await import("../middleware");
+
+    const response = middleware({
+      nextUrl: { pathname: "/dashboard" },
+      cookies: { get: () => ({ value: "broken" }) },
+      url: "http://localhost/dashboard",
+    });
+
+    expect(redirectMock).toHaveBeenCalled();
+    expect(response).toEqual({ type: "redirect", url: "http://localhost/?redirect=%2Fdashboard" });
+  });
+});


### PR DESCRIPTION
## Что исправлено
- закрыт open redirect в auth-flow на `/`, `/login` и post-login redirect
- добавлена безопасная нормализация redirect-целей в общем helper
- `dashboard` теперь возвращает пользователя в auth-flow не только при `401` на загрузке прогресса, но и при `401` во время обработки вакансии и генерации плана
- logout очищает локальный draft `dashboardDraftV1`, чтобы данные не переходили между пользователями одного браузера
- middleware для `/dashboard` теперь отсекает битые и просроченные session cookie по структуре payload и `exp`, а не доверяет одному факту наличия cookie
- `/auth/logout` возвращён под CSRF-защиту

## Тесты
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `cd backend && pytest tests/ -v`

## Результат
- устранены основные уязвимости и логические ошибки, обнаруженные при review `PR #26`
- добавлены negative/edge тесты на redirect, middleware, `401` внутри wizard и CSRF logout

Closes #31
