### PR TITLE
Stage 6: реализовать симуляцию интервью

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -546,16 +546,21 @@ async def interview_answer(
     )
     next_q = next_q_res.scalar_one_or_none()
     if not next_q:
+        all_scores_res = await db.execute(
+            select(InterviewAnswer.score).where(InterviewAnswer.session_id == session.id)
+        )
+        scores = [float(score) for score in all_scores_res.scalars().all() if score is not None]
+        session_score = round(sum(scores) / len(scores), 2) if scores else round(answer_score, 2)
         session.question_id = None
         session.completed_at = datetime.utcnow()
-        session.score = answer_score
+        session.score = session_score
         await db.commit()
         return {
             "feedback": feedback,
             "score": answer_score,
             "completed": True,
-            "session_score": answer_score,
-            "summary": _build_interview_summary([answer_score]),
+            "session_score": session_score,
+            "summary": _build_interview_summary(scores or [answer_score]),
             "next_question_id": None,
             "next_question": None,
         }

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import secrets
+import subprocess
 from datetime import datetime, timedelta
 from io import BytesIO
 from tempfile import NamedTemporaryFile
-import secrets
-import subprocess
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
-from fastapi.responses import RedirectResponse
-from sqlalchemy import select, func, String
-from sqlalchemy.ext.asyncio import AsyncSession
-from striprtf.striprtf import rtf_to_text
 from docx import Document
 from docx.opc.exceptions import PackageNotFoundError
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, Response, UploadFile
+from fastapi.responses import RedirectResponse
+from sqlalchemy import String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from striprtf.striprtf import rtf_to_text
 
 from app.api.schemas import (
     GeneratedPlanOut,
@@ -33,14 +33,24 @@ from app.db.session import get_db
 from app.models import InterviewAnswer, InterviewSession, Plan, Progress, Question, Resume, User
 from app.services.ai_proxy import chat_completion
 from app.services.auth import get_current_user
-from app.services.rate_limit import check_rate_limit
 from app.services.emailer import EmailDeliveryError, send_email
-from app.services.security import create_access_token, hash_email_token, hash_password, verify_password
-from app.services.vacancy_ingest import ingest_vacancy, normalize_text, MAX_VACANCY_TEXT_LENGTH
+from app.services.rate_limit import check_rate_limit
+from app.services.security import (
+    create_access_token,
+    hash_email_token,
+    hash_password,
+    verify_password,
+)
+from app.services.vacancy_ingest import (
+    MAX_VACANCY_TEXT_LENGTH,
+    ingest_vacancy,
+    normalize_text,
+)
 
 router = APIRouter()
 
 MAX_RESUME_FILE_SIZE_BYTES = 5 * 1024 * 1024
+MAX_INTERVIEW_QUESTIONS = 3
 RESUME_ALLOWED_TYPES = {
     ".md": {"text/markdown", "text/plain"},
     ".txt": {"text/plain"},
@@ -50,6 +60,60 @@ RESUME_ALLOWED_TYPES = {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     },
 }
+
+
+def _tokenize_text(value: str) -> set[str]:
+    cleaned = "".join(char.lower() if char.isalnum() else " " for char in value)
+    return {token for token in cleaned.split() if len(token) >= 3}
+
+
+def _score_interview_answer(question: Question, answer: str) -> float:
+    answer_tokens = _tokenize_text(answer)
+    answer_word_count = len(answer.split())
+    if answer_word_count == 0:
+        return 0.0
+
+    reference_tokens = _tokenize_text(question.text)
+    reference_tokens.update(_tokenize_text(question.tags))
+    if question.sample_answer:
+        reference_tokens.update(_tokenize_text(question.sample_answer))
+
+    overlap = len(answer_tokens & reference_tokens)
+    overlap_score = min(35.0, overlap * 8.0)
+
+    depth_score = min(45.0, answer_word_count * 2.5)
+    structure_score = 20.0 if any(mark in answer for mark in (".", ",", ";", ":")) else 10.0
+
+    raw_score = overlap_score + depth_score + structure_score
+    return round(min(100.0, raw_score), 2)
+
+
+def _build_interview_summary(scores: list[float]) -> str:
+    average_score = sum(scores) / len(scores)
+    rounded_score = round(average_score, 2)
+
+    if rounded_score >= 80:
+        verdict = "Сильный результат: ответы в целом полные и по делу."
+    elif rounded_score >= 60:
+        verdict = "Нормальный результат: база есть, но глубину стоит усилить."
+    else:
+        verdict = "Есть заметные пробелы: ответы пока слишком короткие или поверхностные."
+
+    if rounded_score >= 75:
+        next_step = (
+            "Следующий шаг: потренировать более чёткую структуру ответа под реальные интервью."
+        )
+    elif rounded_score >= 50:
+        next_step = (
+            "Следующий шаг: добавить больше конкретики, терминов и причинно-следственных связей."
+        )
+    else:
+        next_step = (
+            "Следующий шаг: повторить теорию по темам интервью "
+            "и отработать развёрнутые ответы вслух."
+        )
+
+    return f"{verdict} Итоговый балл: {rounded_score}/100. {next_step}"
 
 
 @router.post("/auth/signup", response_model=MessageOut)
@@ -87,7 +151,9 @@ async def signup(data: SignupIn, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/auth/login", response_model=MessageOut)
-async def login(request: Request, response: Response, data: LoginIn, db: AsyncSession = Depends(get_db)):
+async def login(
+    request: Request, response: Response, data: LoginIn, db: AsyncSession = Depends(get_db)
+):
     ip = request.client.host if request.client else "unknown"
     rate_limit_key = f"login:{ip}:{data.email.lower()}"
     if not check_rate_limit(rate_limit_key):
@@ -121,7 +187,10 @@ async def verify_email(token: str, db: AsyncSession = Depends(get_db)):
     user = res.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=400, detail="Invalid token")
-    if user.email_verification_expires_at and user.email_verification_expires_at < datetime.utcnow():
+    if (
+        user.email_verification_expires_at
+        and user.email_verification_expires_at < datetime.utcnow()
+    ):
         raise HTTPException(status_code=400, detail="Token expired")
 
     user.email_verified = True
@@ -275,7 +344,8 @@ async def generate_plan(
 
     prompt = (
         "Generate strict JSON only with keys: summary, gap_analysis, weeks, final_readiness_check. "
-        "weeks is an array where each item has week, themes, practice, mock_interview, expected_outcome, time_budget_hours."
+        "weeks is an array where each item has week, themes, practice, "
+        "mock_interview, expected_outcome, time_budget_hours."
     )
     messages = [
         {"role": "system", "content": "You are an interview coach."},
@@ -364,12 +434,22 @@ async def get_questions(
 async def interview_start(
     user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)
 ):
+    total_questions_res = await db.execute(select(func.count(Question.id)))
+    total_questions_in_db = total_questions_res.scalar_one()
+    if total_questions_in_db == 0:
+        raise HTTPException(status_code=400, detail="No questions in database")
+
     res = await db.execute(select(Question).order_by(func.random()).limit(1))
     question = res.scalar_one_or_none()
     if not question:
         raise HTTPException(status_code=400, detail="No questions in database")
 
-    session = InterviewSession(user_id=user.id, question_id=question.id, started_at=datetime.utcnow())
+    session = InterviewSession(
+        user_id=user.id,
+        question_id=question.id,
+        total_questions=min(MAX_INTERVIEW_QUESTIONS, total_questions_in_db),
+        started_at=datetime.utcnow(),
+    )
     db.add(session)
     await db.commit()
     await db.refresh(session)
@@ -383,6 +463,10 @@ async def interview_answer(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    normalized_answer = data.answer.strip()
+    if not normalized_answer:
+        raise HTTPException(status_code=422, detail="Answer must not be empty")
+
     res = await db.execute(
         select(InterviewSession).where(
             InterviewSession.id == data.session_id,
@@ -392,6 +476,9 @@ async def interview_answer(
     session = res.scalar_one_or_none()
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
+
+    if session.completed_at is not None:
+        raise HTTPException(status_code=400, detail="Session already completed")
 
     if not session.question_id or session.question_id != data.question_id:
         raise HTTPException(status_code=400, detail="Question mismatch")
@@ -411,24 +498,77 @@ async def interview_answer(
     except Exception:
         raise HTTPException(status_code=502, detail="Feedback unavailable")
 
+    answer_score = _score_interview_answer(question, normalized_answer)
     answer = InterviewAnswer(
         session_id=session.id,
+        question_id=question.id,
         question=question.text,
-        answer=data.answer,
+        answer=normalized_answer,
         feedback=feedback,
-        score=None,
+        score=answer_score,
     )
     db.add(answer)
+    await db.flush()
+
+    answered_question_ids_res = await db.execute(
+        select(InterviewAnswer.question_id).where(InterviewAnswer.session_id == session.id)
+    )
+    answered_question_ids = [
+        question_id for question_id in answered_question_ids_res.scalars().all()
+    ]
+    answered_count = len(answered_question_ids)
+
+    if answered_count >= session.total_questions:
+        all_scores_res = await db.execute(
+            select(InterviewAnswer.score).where(InterviewAnswer.session_id == session.id)
+        )
+        scores = [float(score) for score in all_scores_res.scalars().all() if score is not None]
+        session_score = round(sum(scores) / len(scores), 2) if scores else round(answer_score, 2)
+        session.question_id = None
+        session.completed_at = datetime.utcnow()
+        session.score = session_score
+        await db.commit()
+        return {
+            "feedback": feedback,
+            "score": answer_score,
+            "completed": True,
+            "session_score": session_score,
+            "summary": _build_interview_summary(scores or [answer_score]),
+            "next_question_id": None,
+            "next_question": None,
+        }
 
     next_q_res = await db.execute(
-        select(Question).where(Question.id != question.id).order_by(func.random()).limit(1)
+        select(Question)
+        .where(Question.id.not_in(answered_question_ids))
+        .order_by(func.random())
+        .limit(1)
     )
     next_q = next_q_res.scalar_one_or_none()
-    session.question_id = next_q.id if next_q else None
+    if not next_q:
+        session.question_id = None
+        session.completed_at = datetime.utcnow()
+        session.score = answer_score
+        await db.commit()
+        return {
+            "feedback": feedback,
+            "score": answer_score,
+            "completed": True,
+            "session_score": answer_score,
+            "summary": _build_interview_summary([answer_score]),
+            "next_question_id": None,
+            "next_question": None,
+        }
+
+    session.question_id = next_q.id
     await db.commit()
 
     return {
         "feedback": feedback,
+        "score": answer_score,
+        "completed": False,
+        "session_score": None,
+        "summary": None,
         "next_question_id": next_q.id if next_q else None,
         "next_question": next_q.text if next_q else None,
     }

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -90,10 +90,14 @@ class InterviewStartOut(BaseModel):
 class InterviewAnswerIn(BaseModel):
     session_id: int
     question_id: int
-    answer: str
+    answer: str = Field(min_length=1, max_length=5000)
 
 
 class InterviewAnswerOut(BaseModel):
     feedback: str
+    score: float = Field(ge=0, le=100)
+    completed: bool
+    session_score: float | None = Field(default=None, ge=0, le=100)
+    summary: str | None = None
     next_question_id: int | None = None
     next_question: str | None = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,29 @@ async def on_startup():
         try:
             await conn.execute(
                 text(
+                    "ALTER TABLE interview_sessions "
+                    "ADD COLUMN IF NOT EXISTS total_questions INTEGER DEFAULT 1"
+                )
+            )
+        except Exception:
+            pass
+        try:
+            await conn.execute(
+                text(
+                    "ALTER TABLE interview_sessions ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP"
+                )
+            )
+        except Exception:
+            pass
+        try:
+            await conn.execute(
+                text("ALTER TABLE interview_answers ADD COLUMN IF NOT EXISTS question_id INTEGER")
+            )
+        except Exception:
+            pass
+        try:
+            await conn.execute(
+                text(
                     "ALTER TABLE users "
                     "ADD COLUMN IF NOT EXISTS email_verified BOOLEAN DEFAULT FALSE"
                 )

--- a/backend/app/models/interview_answer.py
+++ b/backend/app/models/interview_answer.py
@@ -9,6 +9,7 @@ class InterviewAnswer(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     session_id: Mapped[int] = mapped_column(ForeignKey("interview_sessions.id"), nullable=False)
+    question_id: Mapped[int] = mapped_column(ForeignKey("questions.id"), nullable=False)
     question: Mapped[str] = mapped_column(Text, nullable=False)
     answer: Mapped[str] = mapped_column(Text, nullable=False)
     feedback: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/models/interview_session.py
+++ b/backend/app/models/interview_session.py
@@ -12,5 +12,7 @@ class InterviewSession(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     question_id: Mapped[int | None] = mapped_column(ForeignKey("questions.id"))
+    total_questions: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     started_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime)
     score: Mapped[float | None] = mapped_column(Numeric(5, 2))

--- a/backend/tests/test_interview_and_questions.py
+++ b/backend/tests/test_interview_and_questions.py
@@ -299,3 +299,75 @@ async def test_interview_cannot_answer_completed_session(client, monkeypatch):
     )
     assert completed_response.status_code == 400
     assert completed_response.json()["detail"] == "Session already completed"
+
+
+@pytest.mark.asyncio
+async def test_interview_uses_average_score_when_question_pool_shrinks(client, monkeypatch):
+    from app.db.session import SessionLocal
+
+    await _auth(client, email="shrink@test.com")
+    await _seed_questions()
+
+    async def fake_chat_completion(messages, model="openclaw/devius"):
+        return {"choices": [{"message": {"content": "good answer"}}]}
+
+    monkeypatch.setattr("app.api.routes.chat_completion", fake_chat_completion)
+
+    start = await client.post("/interview/start")
+    start_payload = start.json()
+
+    first_answer = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": start_payload["session_id"],
+            "question_id": start_payload["question_id"],
+            "answer": "Короткий ответ.",
+        },
+    )
+    assert first_answer.status_code == 200
+    first_payload = first_answer.json()
+
+    async with SessionLocal() as session:
+        remaining_question_ids = (
+            (
+                await session.execute(
+                    select(Question.id).where(
+                        Question.id.not_in(
+                            [start_payload["question_id"], first_payload["next_question_id"]]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(remaining_question_ids) == 1
+        await session.execute(
+            Question.__table__.delete().where(Question.id == remaining_question_ids[0])
+        )
+        await session.commit()
+
+    second_answer = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": start_payload["session_id"],
+            "question_id": first_payload["next_question_id"],
+            "answer": "Очень подробный ответ с архитектурой, SQL, trade-offs и примерами.",
+        },
+    )
+    assert second_answer.status_code == 200
+    closing_payload = second_answer.json()
+    assert closing_payload["completed"] is True
+
+    async with SessionLocal() as session:
+        answer_scores = (
+            await session.execute(
+                select(InterviewAnswer.score).where(
+                    InterviewAnswer.session_id == start_payload["session_id"]
+                )
+            )
+        ).scalars().all()
+    expected_session_score = round(
+        sum(float(score) for score in answer_scores if score is not None) / len(answer_scores), 2
+    )
+    assert closing_payload["session_score"] == expected_session_score

--- a/backend/tests/test_interview_and_questions.py
+++ b/backend/tests/test_interview_and_questions.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import select
 
-from app.models import InterviewSession, Question, User
+from app.models import InterviewAnswer, InterviewSession, Question, User
 from app.services.security import hash_email_token
 
 
@@ -70,6 +70,8 @@ async def test_interview_start_requires_questions(client):
 
 @pytest.mark.asyncio
 async def test_interview_happy_path_and_followup(client, monkeypatch):
+    from app.db.session import SessionLocal
+
     await _auth(client, email="interview@test.com")
     await _seed_questions()
 
@@ -82,16 +84,77 @@ async def test_interview_happy_path_and_followup(client, monkeypatch):
     assert start.status_code == 200
     payload = start.json()
 
-    answer = await client.post(
+    first_answer = await client.post(
         "/interview/answer",
         json={
             "session_id": payload["session_id"],
             "question_id": payload["question_id"],
-            "answer": "my answer",
+            "answer": "Подробно объясню архитектуру, компромиссы и практические детали решения.",
         },
     )
-    assert answer.status_code == 200
-    assert answer.json()["feedback"] == "good answer"
+    assert first_answer.status_code == 200
+    first_payload = first_answer.json()
+    assert first_payload["feedback"] == "good answer"
+    assert first_payload["completed"] is False
+    assert first_payload["next_question_id"] is not None
+    assert first_payload["next_question_id"] != payload["question_id"]
+    assert first_payload["score"] > 0
+
+    second_answer = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": payload["session_id"],
+            "question_id": first_payload["next_question_id"],
+            "answer": "Разберу пример, ограничения, SQL и граничные случаи.",
+        },
+    )
+    assert second_answer.status_code == 200
+    second_payload = second_answer.json()
+    assert second_payload["completed"] is False
+    assert second_payload["next_question_id"] is not None
+    assert second_payload["next_question_id"] not in {
+        payload["question_id"],
+        first_payload["next_question_id"],
+    }
+
+    final_answer = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": payload["session_id"],
+            "question_id": second_payload["next_question_id"],
+            "answer": "Итоговый ответ с терминами, деталями и понятной структурой.",
+        },
+    )
+    assert final_answer.status_code == 200
+    final_payload = final_answer.json()
+    assert final_payload["completed"] is True
+    assert final_payload["next_question_id"] is None
+    assert final_payload["session_score"] is not None
+    assert "Итоговый балл" in final_payload["summary"]
+
+    async with SessionLocal() as session:
+        answers = (
+            (
+                await session.execute(
+                    select(InterviewAnswer).where(
+                        InterviewAnswer.session_id == payload["session_id"]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(answers) == 3
+        assert len({item.question_id for item in answers}) == 3
+
+        interview_session = (
+            await session.execute(
+                select(InterviewSession).where(InterviewSession.id == payload["session_id"])
+            )
+        ).scalar_one()
+        assert interview_session.question_id is None
+        assert interview_session.completed_at is not None
+        assert float(interview_session.score) == final_payload["session_score"]
 
 
 @pytest.mark.asyncio
@@ -100,6 +163,7 @@ async def test_interview_happy_path_and_followup(client, monkeypatch):
     [
         ("missing_session", 9999, 1, 404, None),
         ("question_mismatch", None, 99999, 400, "Question mismatch"),
+        ("empty_answer", None, None, 422, "Answer must not be empty"),
     ],
 )
 async def test_interview_answer_error_cases(
@@ -111,15 +175,20 @@ async def test_interview_answer_error_cases(
     expected_detail,
 ):
     await _auth(client, email=f"{mode}@test.com")
+    answer = "x"
 
-    if mode == "question_mismatch":
+    if mode in {"question_mismatch", "empty_answer"}:
         await _seed_questions()
         start = await client.post("/interview/start")
-        session_id = start.json()["session_id"]
+        payload = start.json()
+        session_id = payload["session_id"]
+        if mode == "empty_answer":
+            question_id = payload["question_id"]
+            answer = "   "
 
     resp = await client.post(
         "/interview/answer",
-        json={"session_id": session_id, "question_id": question_id, "answer": "x"},
+        json={"session_id": session_id, "question_id": question_id, "answer": answer},
     )
     assert resp.status_code == expected_status
     if expected_detail:
@@ -136,9 +205,13 @@ async def test_interview_answer_question_not_found_after_session_update(client):
     payload = start.json()
 
     async with SessionLocal() as session:
-        res = await session.execute(select(InterviewSession).where(InterviewSession.id == payload["session_id"]))
+        res = await session.execute(
+            select(InterviewSession).where(InterviewSession.id == payload["session_id"])
+        )
         interview_session = res.scalar_one()
-        await session.execute(Question.__table__.delete().where(Question.id == interview_session.question_id))
+        await session.execute(
+            Question.__table__.delete().where(Question.id == interview_session.question_id)
+        )
         await session.commit()
 
     resp = await client.post(
@@ -151,3 +224,78 @@ async def test_interview_answer_question_not_found_after_session_update(client):
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Question not found"
+
+
+@pytest.mark.asyncio
+async def test_interview_single_question_completes_session(client, monkeypatch):
+    from app.db.session import SessionLocal
+
+    await _auth(client, email="single@test.com")
+
+    async with SessionLocal() as session:
+        session.add(
+            Question(text="Only question", topic="python", difficulty="middle", tags="python")
+        )
+        await session.commit()
+
+    async def fake_chat_completion(messages, model="openclaw/devius"):
+        return {"choices": [{"message": {"content": "good answer"}}]}
+
+    monkeypatch.setattr("app.api.routes.chat_completion", fake_chat_completion)
+
+    start = await client.post("/interview/start")
+    payload = start.json()
+
+    answer = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": payload["session_id"],
+            "question_id": payload["question_id"],
+            "answer": "Полный ответ с деталями и примерами.",
+        },
+    )
+    assert answer.status_code == 200
+    result = answer.json()
+    assert result["completed"] is True
+    assert result["next_question"] is None
+    assert result["session_score"] == result["score"]
+
+
+@pytest.mark.asyncio
+async def test_interview_cannot_answer_completed_session(client, monkeypatch):
+    await _auth(client, email="completed@test.com")
+    await _seed_questions()
+
+    async def fake_chat_completion(messages, model="openclaw/devius"):
+        return {"choices": [{"message": {"content": "good answer"}}]}
+
+    monkeypatch.setattr("app.api.routes.chat_completion", fake_chat_completion)
+
+    start = await client.post("/interview/start")
+    current_question_id = start.json()["question_id"]
+
+    for _ in range(3):
+        response = await client.post(
+            "/interview/answer",
+            json={
+                "session_id": start.json()["session_id"],
+                "question_id": current_question_id,
+                "answer": "Развёрнутый ответ с терминологией и примерами.",
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["completed"]:
+            break
+        current_question_id = payload["next_question_id"]
+
+    completed_response = await client.post(
+        "/interview/answer",
+        json={
+            "session_id": start.json()["session_id"],
+            "question_id": current_question_id,
+            "answer": "Ещё один ответ после завершения.",
+        },
+    )
+    assert completed_response.status_code == 400
+    assert completed_response.json()["detail"] == "Session already completed"


### PR DESCRIPTION
## Что сделано
- доработал `POST /interview/start`: теперь создаётся сессия с лимитом вопросов и состоянием завершения
- доработал `POST /interview/answer`: ответы сохраняются в БД, вопросы внутри сессии не повторяются, после финального ответа выставляется итоговый `session_score`
- добавил базовую эвристическую оценку ответа и итоговый summary без дополнительного внешнего шага
- расширил runtime-миграции для существующей БД новыми колонками interview-session/interview-answer
- добавил тесты happy, negative и edge для многошагового интервью

## Проверка
- `pytest backend/tests -q`
- `ruff check backend/app/api/routes.py backend/app/api/schemas.py backend/app/main.py backend/app/models/interview_answer.py backend/app/models/interview_session.py backend/tests/test_interview_and_questions.py --select I,E,F`

## Результат
Пользователь может начать интервью, пройти до трёх вопросов подряд, получить feedback по каждому ответу и итоговый summary с оценкой после завершения.

Closes #34
