### PR TITLE
feat: stage 7 progress tracking API

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import secrets
 import subprocess
 from datetime import datetime, timedelta
@@ -23,6 +24,9 @@ from app.api.schemas import (
     MessageOut,
     PlanGenerateOut,
     PlanIn,
+    ProgressOut,
+    ProgressUpsertIn,
+    ProgressUpsertOut,
     ResendVerificationIn,
     SignupIn,
     VacancyIngestIn,
@@ -51,6 +55,7 @@ router = APIRouter()
 
 MAX_RESUME_FILE_SIZE_BYTES = 5 * 1024 * 1024
 MAX_INTERVIEW_QUESTIONS = 3
+PROGRESS_STATUSES = ("todo", "in_progress", "done")
 RESUME_ALLOWED_TYPES = {
     ".md": {"text/markdown", "text/plain"},
     ".txt": {"text/plain"},
@@ -114,6 +119,108 @@ def _build_interview_summary(scores: list[float]) -> str:
         )
 
     return f"{verdict} Итоговый балл: {rounded_score}/100. {next_step}"
+
+
+def _normalize_progress_topic(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def _extract_topics_from_plan(plan: Plan | None) -> list[str]:
+    if plan is None or not plan.plan_json:
+        return []
+
+    try:
+        payload = json.loads(plan.plan_json)
+    except json.JSONDecodeError:
+        return []
+
+    topics: list[str] = []
+    seen_keys: set[str] = set()
+    for week in payload.get("weeks", []):
+        week_themes = week.get("themes", [])
+        if not isinstance(week_themes, list):
+            continue
+
+        for theme in week_themes:
+            if not isinstance(theme, str):
+                continue
+            normalized = " ".join(theme.split())
+            if not normalized:
+                continue
+            normalized_key = _normalize_progress_topic(normalized)
+            if normalized_key in seen_keys:
+                continue
+            seen_keys.add(normalized_key)
+            topics.append(normalized)
+
+    return topics
+
+
+def _serialize_progress(
+    entries: list[Progress],
+    plan_topics: list[str],
+) -> dict[str, object]:
+    latest_by_topic: dict[str, Progress] = {}
+    ordered_topics: list[str] = []
+    seen_topics: set[str] = set()
+
+    for topic in plan_topics:
+        topic_key = _normalize_progress_topic(topic)
+        if topic_key in seen_topics:
+            continue
+        seen_topics.add(topic_key)
+        ordered_topics.append(topic)
+
+    for entry in entries:
+        topic_key = _normalize_progress_topic(entry.topic)
+        if topic_key not in latest_by_topic:
+            latest_by_topic[topic_key] = entry
+        if topic_key not in seen_topics:
+            seen_topics.add(topic_key)
+            ordered_topics.append(" ".join(entry.topic.split()))
+
+    topics: list[dict[str, object]] = []
+    status_counts = {status: 0 for status in PROGRESS_STATUSES}
+    completed_topics = 0
+
+    for topic in ordered_topics:
+        topic_key = _normalize_progress_topic(topic)
+        latest_entry = latest_by_topic.get(topic_key)
+        current_status = latest_entry.status if latest_entry else "todo"
+        if current_status in status_counts:
+            status_counts[current_status] += 1
+        if current_status == "done":
+            completed_topics += 1
+        topics.append(
+            {
+                "topic": latest_entry.topic if latest_entry else topic,
+                "status": current_status,
+                "updated_at": latest_entry.updated_at if latest_entry else None,
+            }
+        )
+
+    total_topics = len(topics)
+    completion_percent = round((completed_topics / total_topics) * 100, 2) if total_topics else 0.0
+
+    history = [
+        {
+            "topic": " ".join(entry.topic.split()),
+            "status": entry.status,
+            "updated_at": entry.updated_at,
+        }
+        for entry in entries
+    ]
+
+    return {
+        "summary": {
+            "total_topics": total_topics,
+            "completed_topics": completed_topics,
+            "completion_percent": completion_percent,
+            "status_counts": status_counts,
+        },
+        "topics": topics,
+        "history": history,
+    }
 
 
 @router.post("/auth/signup", response_model=MessageOut)
@@ -365,8 +472,6 @@ async def generate_plan(
     except Exception:
         raise HTTPException(status_code=502, detail="Plan generation failed")
 
-    import json
-
     try:
         plan_json = json.loads(content)
     except Exception:
@@ -579,14 +684,68 @@ async def interview_answer(
     }
 
 
-@router.get("/progress")
-async def get_progress(user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
-    res = await db.execute(select(Progress).where(Progress.user_id == user.id))
-    return [
-        {
-            "topic": p.topic,
-            "status": p.status,
-            "updated_at": p.updated_at,
+@router.post("/progress", response_model=ProgressUpsertOut)
+async def upsert_progress(
+    data: ProgressUpsertIn,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    normalized_topic = " ".join(data.topic.split())
+    topic_key = _normalize_progress_topic(normalized_topic)
+
+    latest_res = await db.execute(
+        select(Progress)
+        .where(Progress.user_id == user.id)
+        .order_by(Progress.updated_at.desc(), Progress.id.desc())
+    )
+    latest_entries = latest_res.scalars().all()
+    latest_entry = next(
+        (entry for entry in latest_entries if _normalize_progress_topic(entry.topic) == topic_key),
+        None,
+    )
+
+    if latest_entry and latest_entry.status == data.status:
+        return {
+            "detail": "unchanged",
+            "topic": {
+                "topic": latest_entry.topic,
+                "status": latest_entry.status,
+                "updated_at": latest_entry.updated_at,
+            },
         }
-        for p in res.scalars().all()
-    ]
+
+    progress_entry = Progress(
+        user_id=user.id,
+        topic=normalized_topic,
+        status=data.status,
+        updated_at=datetime.utcnow(),
+    )
+    db.add(progress_entry)
+    await db.commit()
+    await db.refresh(progress_entry)
+
+    return {
+        "detail": "updated" if latest_entry else "created",
+        "topic": {
+            "topic": progress_entry.topic,
+            "status": progress_entry.status,
+            "updated_at": progress_entry.updated_at,
+        },
+    }
+
+
+@router.get("/progress", response_model=ProgressOut)
+async def get_progress(user: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
+    progress_res = await db.execute(
+        select(Progress)
+        .where(Progress.user_id == user.id)
+        .order_by(Progress.updated_at.desc(), Progress.id.desc())
+    )
+    plan_res = await db.execute(
+        select(Plan).where(Plan.user_id == user.id).order_by(Plan.created_at.desc()).limit(1)
+    )
+
+    progress_entries = progress_res.scalars().all()
+    latest_plan = plan_res.scalar_one_or_none()
+    plan_topics = _extract_topics_from_plan(latest_plan)
+    return _serialize_progress(progress_entries, plan_topics)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field, model_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
 
 class SignupIn(BaseModel):
@@ -101,3 +102,52 @@ class InterviewAnswerOut(BaseModel):
     summary: str | None = None
     next_question_id: int | None = None
     next_question: str | None = None
+
+
+class ProgressUpsertIn(BaseModel):
+    topic: str = Field(min_length=1, max_length=120)
+    status: Literal["todo", "in_progress", "done"]
+
+    @field_validator("topic")
+    @classmethod
+    def validate_topic(cls, value: str) -> str:
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("Topic must not be empty")
+        return normalized
+
+
+class ProgressTopicOut(BaseModel):
+    topic: str
+    status: Literal["todo", "in_progress", "done"]
+    updated_at: datetime | None = None
+
+
+class ProgressHistoryOut(BaseModel):
+    topic: str
+    status: Literal["todo", "in_progress", "done"]
+    updated_at: datetime
+
+
+class ProgressStatusCountsOut(BaseModel):
+    todo: int = Field(ge=0)
+    in_progress: int = Field(ge=0)
+    done: int = Field(ge=0)
+
+
+class ProgressSummaryOut(BaseModel):
+    total_topics: int = Field(ge=0)
+    completed_topics: int = Field(ge=0)
+    completion_percent: float = Field(ge=0, le=100)
+    status_counts: ProgressStatusCountsOut
+
+
+class ProgressOut(BaseModel):
+    summary: ProgressSummaryOut
+    topics: list[ProgressTopicOut]
+    history: list[ProgressHistoryOut]
+
+
+class ProgressUpsertOut(BaseModel):
+    detail: Literal["created", "updated", "unchanged"]
+    topic: ProgressTopicOut

--- a/backend/tests/test_routes_e2e.py
+++ b/backend/tests/test_routes_e2e.py
@@ -1,7 +1,9 @@
+import json
+
 import pytest
 from sqlalchemy import select
 
-from app.models import Progress, User
+from app.models import Plan, Progress, User
 from app.services.security import hash_email_token
 
 
@@ -65,7 +67,23 @@ async def test_e2e_core_flow(client, monkeypatch):
             "choices": [
                 {
                     "message": {
-                        "content": '{"summary":"plan","gap_analysis":[],"weeks":[{"week":1,"themes":["Python"],"practice":["API"],"mock_interview":[],"expected_outcome":"ok","time_budget_hours":6}],"final_readiness_check":["done"]}'
+                        "content": json.dumps(
+                            {
+                                "summary": "plan",
+                                "gap_analysis": [],
+                                "weeks": [
+                                    {
+                                        "week": 1,
+                                        "themes": ["Python"],
+                                        "practice": ["API"],
+                                        "mock_interview": [],
+                                        "expected_outcome": "ok",
+                                        "time_budget_hours": 6,
+                                    }
+                                ],
+                                "final_readiness_check": ["done"],
+                            }
+                        )
                     }
                 }
             ]
@@ -114,14 +132,36 @@ async def test_e2e_core_flow(client, monkeypatch):
     )
     assert answer.status_code == 200
 
-    async with SessionLocal() as session:
-        user = (await session.execute(select(User).where(User.email == "e2e-core@test.com"))).scalar_one()
-        session.add(Progress(user_id=user.id, topic="python", status="in_progress"))
-        await session.commit()
+    progress_update = await client.post(
+        "/progress",
+        json={"topic": "Python", "status": "in_progress"},
+    )
+    assert progress_update.status_code == 200
+    assert progress_update.json()["detail"] == "created"
 
     progress = await client.get("/progress")
     assert progress.status_code == 200
-    assert len(progress.json()) == 1
+    progress_payload = progress.json()
+    assert progress_payload["summary"] == {
+        "total_topics": 1,
+        "completed_topics": 0,
+        "completion_percent": 0.0,
+        "status_counts": {"todo": 0, "in_progress": 1, "done": 0},
+    }
+    assert progress_payload["topics"] == [
+        {
+            "topic": "Python",
+            "status": "in_progress",
+            "updated_at": progress_payload["topics"][0]["updated_at"],
+        }
+    ]
+    assert progress_payload["history"] == [
+        {
+            "topic": "Python",
+            "status": "in_progress",
+            "updated_at": progress_payload["history"][0]["updated_at"],
+        }
+    ]
 
     logout = await client.post("/auth/logout")
     assert logout.status_code == 200
@@ -192,3 +232,107 @@ async def test_routes_error_scenarios_extra(client, monkeypatch):
         },
     )
     assert bad_plan.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_progress_aggregates_plan_topics_and_history(client):
+    from app.db.session import SessionLocal
+
+    email = "progress-plan@test.com"
+    await _register_and_login(client, email)
+
+    async with SessionLocal() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        session.add(
+            Plan(
+                user_id=user.id,
+                resume_text="resume",
+                vacancy_text="vacancy",
+                brief_json="{}",
+                plan_json=json.dumps(
+                    {
+                        "summary": "plan",
+                        "gap_analysis": [],
+                        "weeks": [
+                            {
+                                "week": 1,
+                                "themes": ["Python", "SQL"],
+                                "practice": [],
+                                "mock_interview": [],
+                                "expected_outcome": "ok",
+                                "time_budget_hours": 4,
+                            },
+                            {
+                                "week": 2,
+                                "themes": ["System Design", "Python"],
+                                "practice": [],
+                                "mock_interview": [],
+                                "expected_outcome": "ok",
+                                "time_budget_hours": 4,
+                            },
+                        ],
+                        "final_readiness_check": [],
+                    }
+                ),
+                content="{}",
+            )
+        )
+        session.add_all(
+            [
+                Progress(user_id=user.id, topic="Python", status="todo"),
+                Progress(user_id=user.id, topic="Python", status="done"),
+                Progress(user_id=user.id, topic="Algorithms", status="in_progress"),
+            ]
+        )
+        await session.commit()
+
+    resp = await client.get("/progress")
+    assert resp.status_code == 200
+
+    body = resp.json()
+    assert body["summary"] == {
+        "total_topics": 4,
+        "completed_topics": 1,
+        "completion_percent": 25.0,
+        "status_counts": {"todo": 2, "in_progress": 1, "done": 1},
+    }
+    assert body["topics"] == [
+        {"topic": "Python", "status": "done", "updated_at": body["topics"][0]["updated_at"]},
+        {"topic": "SQL", "status": "todo", "updated_at": None},
+        {
+            "topic": "System Design",
+            "status": "todo",
+            "updated_at": None,
+        },
+        {
+            "topic": "Algorithms",
+            "status": "in_progress",
+            "updated_at": body["topics"][3]["updated_at"],
+        },
+    ]
+    assert [(entry["topic"], entry["status"]) for entry in body["history"]] == [
+        ("Algorithms", "in_progress"),
+        ("Python", "done"),
+        ("Python", "todo"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_progress_upsert_returns_unchanged_when_status_matches_latest(client):
+    from app.db.session import SessionLocal
+
+    email = "progress-unchanged@test.com"
+    await _register_and_login(client, email)
+
+    async with SessionLocal() as session:
+        user = (await session.execute(select(User).where(User.email == email))).scalar_one()
+        session.add(Progress(user_id=user.id, topic="Python", status="done"))
+        await session.commit()
+
+    unchanged = await client.post("/progress", json={"topic": "  python  ", "status": "done"})
+    assert unchanged.status_code == 200
+    assert unchanged.json()["detail"] == "unchanged"
+
+    history = await client.get("/progress")
+    assert history.status_code == 200
+    assert len(history.json()["history"]) == 1

--- a/backend/tests/test_routes_edges.py
+++ b/backend/tests/test_routes_edges.py
@@ -126,3 +126,18 @@ async def test_interview_answer_returns_502_on_ai_error(client, monkeypatch):
 async def test_progress_requires_auth(client):
     resp = await client.get("/progress")
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"topic": "   ", "status": "todo"},
+        {"topic": "Python", "status": "paused"},
+    ],
+)
+async def test_progress_rejects_invalid_payload(client, payload):
+    await _signup_verify_login(client, email="edge-progress@test.com")
+
+    resp = await client.post("/progress", json=payload)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Что сделано
- добавил полноценный контракт для progress API: `POST /progress` и агрегированный `GET /progress`
- перевёл progress-трекинг на событийную модель: каждое изменение статуса сохраняется в истории, а текущий статус вычисляется по последней записи темы
- научил `GET /progress` подтягивать темы из последнего сгенерированного плана пользователя, убирать дубли и возвращать сводку по статусам с процентом выполнения
- добавил защиту от пустых тем, невалидных статусов и лишних дублей при повторной отправке того же статуса
- обновил e2e и edge тесты для happy, negative и edge сценариев progress tracking

## Проверка
- `ruff format app/api/routes.py app/api/schemas.py tests/test_routes_e2e.py tests/test_routes_edges.py`
- `ruff check --fix app/api/routes.py app/api/schemas.py tests/test_routes_e2e.py tests/test_routes_edges.py --select I,E,F`
- `pytest tests/ -q`

## Результат
Backend теперь умеет хранить историю прогресса по темам, возвращать агрегированную картину подготовки пользователя и инициализировать темы из последнего учебного плана.

Closes #36
